### PR TITLE
Update action.php for custom plugins directory

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,7 +19,7 @@
 
 if (!defined('DOKU_INC')) die();
 
-require_once DOKU_PLUGIN.action.php';
+require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_aceeditor extends DokuWiki_Action_Plugin {
 

--- a/action.php
+++ b/action.php
@@ -19,7 +19,7 @@
 
 if (!defined('DOKU_INC')) die();
 
-require_once DOKU_INC.'lib/plugins/action.php';
+require_once DOKU_PLUGIN.action.php';
 
 class action_plugin_aceeditor extends DokuWiki_Action_Plugin {
 


### PR DESCRIPTION
The utilization of DOKU_INC.'lib/plugins/' is redundant, since the constant DOKU_PLUGIN is available. Without this update, customized configurations that utilize a separate volume and directory for data, will error since this hard-coded string may not contain the correct file.
